### PR TITLE
Improve Redis lock handling and tests

### DIFF
--- a/xksms-modules/xksms-user/xksms-user-biz/src/main/java/com/xksms/user/biz/TestController.java
+++ b/xksms-modules/xksms-user/xksms-user-biz/src/main/java/com/xksms/user/biz/TestController.java
@@ -36,7 +36,7 @@ public class TestController {
 		throw new RuntimeException("error");
 	}
 
-	//一个占用cpu 和 200m内存的线程
+	// 一个主要用于模拟高 CPU 占用场景的测试接口
 	@GetMapping("/cpu")
 	public String cpu() {
 		for (int i = 0; i < 1000000000; i++) {

--- a/xksms-starters/xksms-starter-redis/pom.xml
+++ b/xksms-starters/xksms-starter-redis/pom.xml
@@ -45,6 +45,12 @@
             <scope>provided</scope>
         </dependency>
 
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
 </project>

--- a/xksms-starters/xksms-starter-redis/src/main/java/com/xksms/redis/RedisHelper.java
+++ b/xksms-starters/xksms-starter-redis/src/main/java/com/xksms/redis/RedisHelper.java
@@ -3,8 +3,11 @@ package com.xksms.redis;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.script.DefaultRedisScript;
+import org.springframework.data.redis.core.script.RedisScript;
 
 import java.time.Duration;
+import java.util.Collections;
 import java.util.Optional;
 
 /**
@@ -16,6 +19,10 @@ import java.util.Optional;
 public final class RedisHelper {
 	//log
 	private static final Logger log = LoggerFactory.getLogger(RedisHelper.class);
+
+	private static final RedisScript<Long> RELEASE_LOCK_SCRIPT = new DefaultRedisScript<>(
+		"if redis.call('get', KEYS[1]) == ARGV[1] then return redis.call('del', KEYS[1]) else return 0 end",
+		Long.class);
 
 	private final RedisTemplate<String, Object> redisTemplate;
 
@@ -70,8 +77,8 @@ public final class RedisHelper {
 
 		// 4. 如果类型不匹配，这是一个危险信号，说明可能存在数据污染或逻辑错误
 		// 我们不应该抛出异常让调用者崩溃，而是记录一条警告，并返回空 Optional，保证方法的健壮性
-		log.warn("Redis alet! Key '{}' 的值类型为 '{}', 但业务期望的类型为 '{}'。可能存在数据污染，已作安全处理。",
-				key, value.getClass().getName(), type.getName());
+		log.warn("Redis alert! Key '{}' 的值类型为 '{}', 但业务期望的类型为 '{}'。可能存在数据污染，已作安全处理。",
+			key, value.getClass().getName(), type.getName());
 		return Optional.empty();
 	}
 
@@ -120,10 +127,8 @@ public final class RedisHelper {
 	 * @return 是否成功释放
 	 */
 	public boolean releaseLock(String lockKey, String requestId) {
-		// 简单的 LUA 脚本保证“先比较、再删除”的原子性
-		String script = "if redis.call('get', KEYS[1]) == ARGV[1] then return redis.call('del', KEYS[1]) else return 0 end";
-		// 此处需要配置并使用 RedisScript
-		// 这是一个更复杂的实现，暂时作为示例
-		return false; // 简化示例
+		// 使用 Lua 保证“先比较、再删除”的原子性
+		Long result = redisTemplate.execute(RELEASE_LOCK_SCRIPT, Collections.singletonList(lockKey), requestId);
+		return result != null && result > 0;
 	}
 }

--- a/xksms-starters/xksms-starter-redis/src/test/java/com/xksms/redis/RedisHelperTest.java
+++ b/xksms-starters/xksms-starter-redis/src/test/java/com/xksms/redis/RedisHelperTest.java
@@ -1,0 +1,76 @@
+package com.xksms.redis;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.data.redis.core.script.RedisScript;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class RedisHelperTest {
+
+    private static final String KEY = "demo";
+    private static final String LOCK_KEY = "lock";
+    private static final String REQUEST_ID = "request";
+
+    @Mock
+    private RedisTemplate<String, Object> redisTemplate;
+
+    @Mock
+    private ValueOperations<String, Object> valueOperations;
+
+    private RedisHelper redisHelper;
+
+    @BeforeEach
+    void setUp() {
+        redisHelper = new RedisHelper(redisTemplate);
+        when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+    }
+
+    @Test
+    void getReturnsEmptyWhenValueTypeDoesNotMatchRequestedType() {
+        when(valueOperations.get(KEY)).thenReturn(42L);
+
+        Optional<String> result = redisHelper.get(KEY, String.class);
+
+        assertThat(result).isEmpty();
+        verify(valueOperations).get(KEY);
+    }
+
+    @Test
+    void releaseLockUsesLuaScriptAndReturnsTrueWhenKeyIsDeleted() {
+        when(redisTemplate.execute(any(RedisScript.class), anyList(), any())).thenReturn(1L);
+
+        boolean released = redisHelper.releaseLock(LOCK_KEY, REQUEST_ID);
+
+        assertThat(released).isTrue();
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<List<String>> keysCaptor = ArgumentCaptor.forClass(List.class);
+        verify(redisTemplate).execute(any(RedisScript.class), keysCaptor.capture(), eq(REQUEST_ID));
+        assertThat(keysCaptor.getValue()).containsExactly(LOCK_KEY);
+    }
+
+    @Test
+    void releaseLockReturnsFalseWhenRedisDoesNotDeleteKey() {
+        when(redisTemplate.execute(any(RedisScript.class), anyList(), any())).thenReturn(0L);
+
+        boolean released = redisHelper.releaseLock(LOCK_KEY, REQUEST_ID);
+
+        assertThat(released).isFalse();
+    }
+}


### PR DESCRIPTION
## Summary
- fix a typo in the Redis helper warning log and implement the Lua-based `releaseLock` helper
- add unit coverage for Redis helper behaviours and include the Spring Boot test dependency in the starter
- clarify the CPU load test comment in `TestController`

## Testing
- `mvn -pl xksms-starters/xksms-starter-redis test` *(fails: repository downloads require network access)*

------
https://chatgpt.com/codex/tasks/task_b_68d35c57993c832884eabb376a72f900