### PR TITLE
feat: add web console for xksms cloud

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,10 @@
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
+
+# Node / Frontend artifacts
+node_modules/
+xksms-frontend/node_modules/
+xksms-frontend/dist/
+.DS_Store
+xksms-frontend/.env*

--- a/README.md
+++ b/README.md
@@ -176,3 +176,15 @@ xksms-cloud
 3.  提交代码
 4.  新建 Pull Request
 
+
+## 🌐 前端控制台（xksms-frontend）
+
+- 技术栈：Vite + React 18 + TypeScript + React Router + React Query。
+- 功能概览：
+  - ✅ 用户中心接口调试：支持通过用户 ID 调用 `/users/{id}` 接口并展示全局统一响应包装结果。
+  - ✅ 通知流观测：基于 Server-Sent Events 连接 `/notifications/stream/{userId}`，实时展示最新 50 条通知消息。
+- 快速开始：
+  1. `cd xksms-frontend`
+  2. `npm install`
+  3. `npm run dev`
+- 环境变量：通过 `VITE_API_BASE_URL` 指定后端网关地址（默认 `http://localhost:8080`）。

--- a/xksms-frontend/.eslintrc.cjs
+++ b/xksms-frontend/.eslintrc.cjs
@@ -1,0 +1,24 @@
+module.exports = {
+  root: true,
+  env: {
+    browser: true,
+    es2021: true,
+  },
+  extends: ['eslint:recommended', 'plugin:react/recommended', 'plugin:react-hooks/recommended', 'prettier'],
+  parserOptions: {
+    ecmaVersion: 'latest',
+    sourceType: 'module',
+    ecmaFeatures: {
+      jsx: true,
+    },
+  },
+  settings: {
+    react: {
+      version: 'detect',
+    },
+  },
+  rules: {
+    'react/react-in-jsx-scope': 'off',
+    'react/prop-types': 'off',
+  },
+};

--- a/xksms-frontend/README.md
+++ b/xksms-frontend/README.md
@@ -1,0 +1,33 @@
+# XKSMS Cloud Web Console
+
+基于 Vite + React + TypeScript 构建的前端控制台，用于联调 `xksms-cloud` 后端的核心示例接口：
+
+- 用户中心：`GET /users/{id}`
+- 通知中心：`GET /notifications/stream/{userId}` (Server-Sent Events)
+
+## 快速开始
+
+```bash
+cd xksms-frontend
+npm install
+npm run dev
+```
+
+默认后端地址为 `http://localhost:8080`，可通过 `.env` 或运行命令时注入 `VITE_API_BASE_URL` 覆盖。
+
+## 目录结构
+
+```
+src/
+├── api          # Axios 实例与接口类型定义
+├── components   # UI 组件（通知流、用户查询卡片等）
+├── hooks        # 自定义 Hooks（SSE 通知流）
+├── pages        # 页面级组件
+└── styles.css   # 全局样式
+```
+
+## 设计亮点
+
+- 使用 React Query 管理异步请求缓存与状态。
+- 封装 SSE 连接 Hook，自动清理连接并限制通知列表长度。
+- 轻量化 UI，便于快速扩展到更多业务模块。

--- a/xksms-frontend/index.html
+++ b/xksms-frontend/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>XKSMS Cloud 控制台</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/xksms-frontend/package.json
+++ b/xksms-frontend/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "xksms-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview",
+    "lint": "eslint ."
+  },
+  "dependencies": {
+    "@tanstack/react-query": "^5.51.6",
+    "axios": "^1.7.7",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "react-router-dom": "^6.26.2",
+    "dayjs": "^1.11.13"
+  },
+  "devDependencies": {
+    "@types/react": "^18.3.8",
+    "@types/react-dom": "^18.3.3",
+    "@vitejs/plugin-react": "^4.3.1",
+    "eslint": "^8.57.1",
+    "eslint-config-prettier": "^9.1.0",
+    "eslint-plugin-react": "^7.35.2",
+    "eslint-plugin-react-hooks": "^4.6.2",
+    "typescript": "^5.4.5",
+    "vite": "^5.4.10"
+  }
+}

--- a/xksms-frontend/src/App.tsx
+++ b/xksms-frontend/src/App.tsx
@@ -1,0 +1,26 @@
+import { Link, Route, Routes } from 'react-router-dom';
+import DashboardPage from './pages/DashboardPage';
+import NotificationsPage from './pages/NotificationsPage';
+
+function App() {
+  return (
+    <div className="app">
+      <header className="app__header">
+        <h1>XKSMS Cloud 控制台</h1>
+        <nav className="app__nav">
+          <Link to="/">概览</Link>
+          <Link to="/notifications">通知流</Link>
+        </nav>
+      </header>
+      <main className="app__content">
+        <Routes>
+          <Route path="/" element={<DashboardPage />} />
+          <Route path="/notifications" element={<NotificationsPage />} />
+        </Routes>
+      </main>
+      <footer className="app__footer">© {new Date().getFullYear()} XKSMS Cloud</footer>
+    </div>
+  );
+}
+
+export default App;

--- a/xksms-frontend/src/api/client.ts
+++ b/xksms-frontend/src/api/client.ts
@@ -1,0 +1,11 @@
+import axios from 'axios';
+
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL ?? 'http://localhost:8080';
+
+export const client = axios.create({
+  baseURL: API_BASE_URL,
+  timeout: 10_000,
+  headers: {
+    'Content-Type': 'application/json',
+  },
+});

--- a/xksms-frontend/src/api/types.ts
+++ b/xksms-frontend/src/api/types.ts
@@ -1,0 +1,18 @@
+export interface ApiResponse<T> {
+  code: number;
+  message: string;
+  data: T;
+}
+
+export interface User {
+  id: number;
+  username: string;
+}
+
+export interface Notification {
+  eventId: string;
+  recipientId: string;
+  type: string;
+  content: string;
+  timestamp: string;
+}

--- a/xksms-frontend/src/components/NotificationStream.tsx
+++ b/xksms-frontend/src/components/NotificationStream.tsx
@@ -1,0 +1,75 @@
+import { FormEvent, useState } from 'react';
+import dayjs from 'dayjs';
+import relativeTime from 'dayjs/plugin/relativeTime';
+import 'dayjs/locale/zh-cn';
+import { useNotificationStream } from '../hooks/useNotificationStream';
+
+dayjs.extend(relativeTime);
+dayjs.locale('zh-cn');
+
+const NotificationStream = () => {
+  const [userId, setUserId] = useState('');
+  const [activeUserId, setActiveUserId] = useState<string | undefined>();
+  const { notifications, isConnected, error } = useNotificationStream({
+    userId: activeUserId,
+    enabled: Boolean(activeUserId),
+  });
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setActiveUserId(userId.trim() || undefined);
+  };
+
+  return (
+    <div>
+      <form onSubmit={handleSubmit}>
+        <div className="input-group">
+          <label htmlFor="notification-user">接收用户 ID</label>
+          <input
+            id="notification-user"
+            type="text"
+            placeholder="输入 userId，例如 user-001"
+            value={userId}
+            onChange={(event) => setUserId(event.target.value)}
+          />
+        </div>
+        <button type="submit">连接通知流</button>
+      </form>
+
+      {activeUserId ? (
+        <p className="sse-status">
+          {isConnected
+            ? `已连接到 ${activeUserId} 的通知流。`
+            : '正在尝试建立通知连接…'}
+        </p>
+      ) : (
+        <div className="empty-state">请输入用户 ID 后开始监听通知。</div>
+      )}
+
+      {error && <div className="error-banner">{error}</div>}
+
+      {activeUserId && notifications.length === 0 && !error && (
+        <div className="empty-state">暂未接收到通知，请触发后台推送。</div>
+      )}
+
+      {notifications.length > 0 && (
+        <div className="notification-list" style={{ marginTop: '1.5rem' }}>
+          {notifications.map((notification) => (
+            <div key={notification.eventId} className="notification-item">
+              <div className="notification-item__meta">
+                <span className="badge">{notification.type}</span>
+                <span style={{ marginLeft: '0.75rem' }}>
+                  {dayjs(notification.timestamp).fromNow()}
+                </span>
+              </div>
+              <strong>{notification.content}</strong>
+              <p>接收者：{notification.recipientId}</p>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default NotificationStream;

--- a/xksms-frontend/src/components/NotificationStreamCard.tsx
+++ b/xksms-frontend/src/components/NotificationStreamCard.tsx
@@ -1,0 +1,11 @@
+import NotificationStream from './NotificationStream';
+
+const NotificationStreamCard = () => (
+  <div className="card">
+    <h2>通知推送监控</h2>
+    <p>输入用户 ID 后，实时跟踪后端推送的通知事件。</p>
+    <NotificationStream />
+  </div>
+);
+
+export default NotificationStreamCard;

--- a/xksms-frontend/src/components/UserLookupCard.tsx
+++ b/xksms-frontend/src/components/UserLookupCard.tsx
@@ -1,0 +1,11 @@
+import UserSearch from './UserSearch';
+
+const UserLookupCard = () => (
+  <div className="card">
+    <h2>用户信息查询</h2>
+    <p>验证用户中心接口，确认全局响应包装是否符合预期。</p>
+    <UserSearch />
+  </div>
+);
+
+export default UserLookupCard;

--- a/xksms-frontend/src/components/UserSearch.tsx
+++ b/xksms-frontend/src/components/UserSearch.tsx
@@ -1,0 +1,62 @@
+import { FormEvent, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { client } from '../api/client';
+import type { ApiResponse, User } from '../api/types';
+
+const fetchUser = async (userId: number): Promise<ApiResponse<User>> => {
+  const { data } = await client.get<ApiResponse<User>>(`/users/${userId}`);
+  return data;
+};
+
+const UserSearch = () => {
+  const [userId, setUserId] = useState<number | ''>('');
+  const { data, isFetching, isError, error, refetch } = useQuery({
+    queryKey: ['user', userId],
+    queryFn: () => fetchUser(Number(userId)),
+    enabled: false,
+    retry: false,
+  });
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!userId) return;
+    refetch();
+  };
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <div className="input-group">
+        <label htmlFor="userId">用户 ID</label>
+        <input
+          id="userId"
+          type="number"
+          min={1}
+          placeholder="例如 1"
+          value={userId}
+          onChange={(event) => setUserId(event.target.value ? Number(event.target.value) : '')}
+        />
+      </div>
+      <button type="submit" disabled={!userId || isFetching}>
+        {isFetching ? '查询中…' : '获取用户信息'}
+      </button>
+
+      {data && (
+        <div className="notification-item" style={{ marginTop: '1.5rem' }}>
+          <div className="notification-item__meta">
+            <span className="badge">ID #{data.data.id}</span>
+          </div>
+          <strong>{data.data.username}</strong>
+          <p>接口调用成功，全局响应包装正常工作。</p>
+        </div>
+      )}
+
+      {isError && (
+        <div className="error-banner">
+          {(error as Error).message || '查询失败，请稍后重试。'}
+        </div>
+      )}
+    </form>
+  );
+};
+
+export default UserSearch;

--- a/xksms-frontend/src/env.d.ts
+++ b/xksms-frontend/src/env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="vite/client" />
+
+declare module '*.png';
+declare module '*.jpg';
+declare module '*.svg';

--- a/xksms-frontend/src/hooks/useNotificationStream.ts
+++ b/xksms-frontend/src/hooks/useNotificationStream.ts
@@ -1,0 +1,63 @@
+import { useEffect, useRef, useState } from 'react';
+import type { Notification } from '../api/types';
+
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL ?? 'http://localhost:8080';
+
+interface UseNotificationStreamOptions {
+  userId?: string;
+  enabled?: boolean;
+}
+
+export const useNotificationStream = ({ userId, enabled = false }: UseNotificationStreamOptions) => {
+  const eventSourceRef = useRef<EventSource | null>(null);
+  const [notifications, setNotifications] = useState<Notification[]>([]);
+  const [isConnected, setIsConnected] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!enabled || !userId) {
+      setNotifications([]);
+      setError(null);
+      setIsConnected(false);
+      if (eventSourceRef.current) {
+        eventSourceRef.current.close();
+        eventSourceRef.current = null;
+      }
+      return;
+    }
+
+    const url = `${API_BASE_URL}/notifications/stream/${userId}`;
+    const source = new EventSource(url);
+    eventSourceRef.current = source;
+    setNotifications([]);
+    setError(null);
+    setIsConnected(false);
+
+    source.onopen = () => {
+      setIsConnected(true);
+      setError(null);
+    };
+
+    source.onmessage = (event) => {
+      try {
+        const data = JSON.parse(event.data) as Notification;
+        setNotifications((prev) => [data, ...prev].slice(0, 50));
+      } catch (err) {
+        console.error('无法解析通知消息', err);
+      }
+    };
+
+    source.onerror = () => {
+      setIsConnected(false);
+      setError('通知连接中断，将尝试自动重连。');
+    };
+
+    return () => {
+      source.close();
+      eventSourceRef.current = null;
+      setIsConnected(false);
+    };
+  }, [enabled, userId]);
+
+  return { notifications, isConnected, error };
+};

--- a/xksms-frontend/src/main.tsx
+++ b/xksms-frontend/src/main.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import App from './App';
+import './styles.css';
+
+const queryClient = new QueryClient();
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <QueryClientProvider client={queryClient}>
+      <BrowserRouter>
+        <App />
+      </BrowserRouter>
+    </QueryClientProvider>
+  </React.StrictMode>,
+);

--- a/xksms-frontend/src/pages/DashboardPage.tsx
+++ b/xksms-frontend/src/pages/DashboardPage.tsx
@@ -1,0 +1,13 @@
+import NotificationStreamCard from '../components/NotificationStreamCard';
+import UserLookupCard from '../components/UserLookupCard';
+
+const DashboardPage = () => (
+  <div className="page">
+    <div className="card-grid">
+      <UserLookupCard />
+      <NotificationStreamCard />
+    </div>
+  </div>
+);
+
+export default DashboardPage;

--- a/xksms-frontend/src/pages/NotificationsPage.tsx
+++ b/xksms-frontend/src/pages/NotificationsPage.tsx
@@ -1,0 +1,13 @@
+import NotificationStream from '../components/NotificationStream';
+
+const NotificationsPage = () => (
+  <div className="page">
+    <div className="card">
+      <h2>实时通知</h2>
+      <p>选择用户后，将通过 Server-Sent Events 接收后台推送的通知。</p>
+      <NotificationStream />
+    </div>
+  </div>
+);
+
+export default NotificationsPage;

--- a/xksms-frontend/src/styles.css
+++ b/xksms-frontend/src/styles.css
@@ -1,0 +1,202 @@
+:root {
+  color-scheme: light dark;
+  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  line-height: 1.5;
+  font-weight: 400;
+  color: #1f2933;
+  background-color: #f1f5f9;
+}
+
+a {
+  font-weight: 500;
+  color: #2563eb;
+  text-decoration: none;
+}
+
+a:hover {
+  color: #1d4ed8;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+}
+
+.app {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+
+.app__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem 2rem;
+  background-color: #1d4ed8;
+  color: #fff;
+  box-shadow: 0 2px 8px rgba(15, 23, 42, 0.2);
+}
+
+.app__nav {
+  display: flex;
+  gap: 1rem;
+}
+
+.app__nav a {
+  color: #cbd5f5;
+  transition: color 0.2s ease;
+}
+
+.app__nav a.active,
+.app__nav a:hover {
+  color: #fff;
+}
+
+.app__content {
+  flex: 1;
+  padding: 2rem;
+  display: flex;
+  justify-content: center;
+  background-color: #f8fafc;
+}
+
+.app__footer {
+  text-align: center;
+  padding: 1rem;
+  font-size: 0.875rem;
+  color: #64748b;
+  background-color: #e2e8f0;
+}
+
+.page {
+  width: min(960px, 100%);
+}
+
+.card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 1.5rem;
+}
+
+.card {
+  background: white;
+  border-radius: 12px;
+  padding: 1.5rem;
+  box-shadow: 0 10px 25px -10px rgba(15, 23, 42, 0.25);
+  border: 1px solid #e2e8f0;
+}
+
+.card h2 {
+  margin-top: 0;
+  margin-bottom: 0.75rem;
+  font-size: 1.25rem;
+}
+
+.card p {
+  margin-top: 0;
+  margin-bottom: 1rem;
+  color: #475569;
+}
+
+.input-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+input[type='text'],
+input[type='number'] {
+  padding: 0.75rem 1rem;
+  border-radius: 8px;
+  border: 1px solid #cbd5e1;
+  font-size: 1rem;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+input[type='text']:focus,
+input[type='number']:focus {
+  border-color: #2563eb;
+  box-shadow: 0 0 0 4px rgba(37, 99, 235, 0.1);
+  outline: none;
+}
+
+button {
+  align-self: flex-start;
+  padding: 0.75rem 1.5rem;
+  border-radius: 9999px;
+  border: none;
+  background-color: #2563eb;
+  color: white;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease;
+}
+
+button:hover {
+  background-color: #1d4ed8;
+  transform: translateY(-1px);
+  box-shadow: 0 10px 20px -12px rgba(37, 99, 235, 0.5);
+}
+
+button:disabled {
+  background-color: #94a3b8;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+.notification-list {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  max-height: 360px;
+  overflow-y: auto;
+}
+
+.notification-item {
+  border-left: 4px solid #2563eb;
+  padding: 1rem;
+  background-color: #f8fafc;
+  border-radius: 8px;
+  box-shadow: inset 0 0 0 1px #e2e8f0;
+}
+
+.notification-item__meta {
+  font-size: 0.875rem;
+  color: #64748b;
+  margin-bottom: 0.5rem;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.125rem 0.5rem;
+  border-radius: 9999px;
+  background-color: #e0e7ff;
+  color: #3730a3;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+}
+
+.empty-state {
+  text-align: center;
+  color: #94a3b8;
+  padding: 2rem 1rem;
+}
+
+.error-banner {
+  padding: 0.75rem 1rem;
+  border-radius: 8px;
+  background-color: #fee2e2;
+  color: #b91c1c;
+  margin-top: 1rem;
+}
+
+.sse-status {
+  margin-top: 1rem;
+  font-size: 0.875rem;
+  color: #2563eb;
+}

--- a/xksms-frontend/tsconfig.json
+++ b/xksms-frontend/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "jsx": "react-jsx",
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "types": ["vite/client"],
+    "baseUrl": "./src",
+    "paths": {
+      "@/*": ["./*"]
+    }
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/xksms-frontend/tsconfig.node.json
+++ b/xksms-frontend/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/xksms-frontend/vite.config.ts
+++ b/xksms-frontend/vite.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173,
+    host: true,
+    proxy: {
+      '/api': {
+        target: process.env.VITE_API_BASE_URL || 'http://localhost:8080',
+        changeOrigin: true,
+        rewrite: (path) => path.replace(/^\/api/, ''),
+      },
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- scaffold a Vite + React + TypeScript web console for user lookup and notification streaming
- add reusable hooks, styling, and documentation for the new frontend module
- update repository ignore rules and root README with frontend usage guidance

## Testing
- npm install (fails: 403 Forbidden from npm registry in sandbox)


------
https://chatgpt.com/codex/tasks/task_b_68e729d8aba4832aad411f9cd5e89706